### PR TITLE
Fix for .Hugo deprecation.  (second try)

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -7,7 +7,7 @@
 	<link rel="icon" href="{{ $.Site.BaseURL }}{{ $.Site.Params.favicon }}" />
 	<meta name="description" content="{{ $.Site.Params.description }}" />
 
-	{{ .Hugo.Generator }}
+	{{ hugo.Generator }}
 
 	{{ if .Site.GoogleAnalytics }}
 	{{ template "_internal/google_analytics.html" . }}


### PR DESCRIPTION
Building sites… WARN 2019/06/01 12:28:30 Page's .Hugo is deprecated and will be removed in a future release. Use the global hugo function.

Fixed by updating deprecated ".Hugo" to "hugo" in layouts/partials/head.html